### PR TITLE
Fix film type change bug

### DIFF
--- a/backend/InitDatabase.py
+++ b/backend/InitDatabase.py
@@ -116,10 +116,11 @@ class InitDatabase:
         }
 
         cachedTmdbFilmData = self.database.read("cachedTmdbFilmData")
+        cachedLetterboxdTitles = self.database.read("cachedLetterboxdTitles")
+        allFilmDataFilmIds = list(allFilmData.keys())
+        cachedTmdbFilmData = removeCachedTmdbFilmDataAndLetterboxdTitlesNotInAllFilmData(allFilmDataFilmIds, cachedTmdbFilmData, cachedLetterboxdTitles)
 
         allCountries = []
-
-        allFilmDataFilmIds = list(allFilmData.keys())
 
         minImdbRating = allFilmData[allFilmDataFilmIds[0]]['imdbRating']
         maxImdbRating = allFilmData[allFilmDataFilmIds[0]]['imdbRating']
@@ -130,7 +131,6 @@ class InitDatabase:
         minRuntime = allFilmData[allFilmDataFilmIds[0]]['runtime']
         maxRuntime = allFilmData[allFilmDataFilmIds[0]]['runtime']
 
-        cachedLetterboxdTitles = self.database.read("cachedLetterboxdTitles")
         cachedCountries = self.database.read("cachedCountries")
         
         count = 0
@@ -339,6 +339,24 @@ class InitDatabase:
             minutes = ""
 
         return f"{hours}{minutes}"
+
+
+def removeCachedTmdbFilmDataAndLetterboxdTitlesNotInAllFilmData(allFilmData, cachedTmdbFilmData, cachedLetterboxdTitles):
+    invalidFilms = []
+    allFilmDataFilmIds = list(allFilmData.keys())
+    for cachedTmdbFilmId in cachedTmdbFilmData:
+            if cachedTmdbFilmId not in allFilmDataFilmIds:
+                invalidFilms.append({"imdbFilmId": cachedTmdbFilmId, 
+                                     "letterboxdTitle": cachedTmdbFilmData[cachedTmdbFilmId]['letterboxdTitle']})
+                del cachedTmdbFilmData[cachedTmdbFilmId]
+
+    for invalidFilm in invalidFilms:
+        for cachedFilm in cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]:
+            if cachedFilm['imdbFilmId'] == invalidFilm['imdbFilmId']:
+                del cachedFilm
+            
+        if len(cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]) == 0:
+            del cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]
 
 
 if __name__ == "__main__":

--- a/backend/InitDatabase.py
+++ b/backend/InitDatabase.py
@@ -118,7 +118,7 @@ class InitDatabase:
         cachedTmdbFilmData = self.database.read("cachedTmdbFilmData")
         cachedLetterboxdTitles = self.database.read("cachedLetterboxdTitles")
         allFilmDataFilmIds = list(allFilmData.keys())
-        cachedTmdbFilmData = removeCachedTmdbFilmDataAndLetterboxdTitlesNotInAllFilmData(allFilmDataFilmIds, cachedTmdbFilmData, cachedLetterboxdTitles)
+        removeCachedTmdbFilmDataAndLetterboxdTitlesNotInAllFilmData(allFilmDataFilmIds, cachedTmdbFilmData, cachedLetterboxdTitles)
 
         allCountries = []
 
@@ -344,16 +344,21 @@ class InitDatabase:
 def removeCachedTmdbFilmDataAndLetterboxdTitlesNotInAllFilmData(allFilmData, cachedTmdbFilmData, cachedLetterboxdTitles):
     invalidFilms = []
     allFilmDataFilmIds = list(allFilmData.keys())
-    for cachedTmdbFilmId in cachedTmdbFilmData:
+    
+    for cachedTmdbFilmId in list(cachedTmdbFilmData):
             if cachedTmdbFilmId not in allFilmDataFilmIds:
                 invalidFilms.append({"imdbFilmId": cachedTmdbFilmId, 
                                      "letterboxdTitle": cachedTmdbFilmData[cachedTmdbFilmId]['letterboxdTitle']})
                 del cachedTmdbFilmData[cachedTmdbFilmId]
 
     for invalidFilm in invalidFilms:
-        for cachedFilm in cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]:
-            if cachedFilm['imdbFilmId'] == invalidFilm['imdbFilmId']:
-                del cachedFilm
+        i = 0
+        while i < len(cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]):
+            if cachedLetterboxdTitles[invalidFilm['letterboxdTitle']][i]['imdbFilmId'] == invalidFilm['imdbFilmId']:
+                del cachedLetterboxdTitles[invalidFilm['letterboxdTitle']][i]
+                i = i - 1
+            
+            i = i + 1
             
         if len(cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]) == 0:
             del cachedLetterboxdTitles[invalidFilm['letterboxdTitle']]


### PR DESCRIPTION
There was an edge case causing a bug, where a film could be added to cachedTmdbFilmData and cachedLetterboxdTitles because IMDb once considered it a movie, and then later on the IMDB database, they change that film to a TV series, so when initDatabase.sh is run, it runs into a bug because there exists films in cachedTmdbFilmData and cachedLetterboxdTitles that are not in allFilmData.